### PR TITLE
Removed disable_existing_loggers from tribler.py, will break Dispersy

### DIFF
--- a/Tribler/Main/tribler.py
+++ b/Tribler/Main/tribler.py
@@ -14,7 +14,7 @@
 
 import logging.config
 from Tribler.Core.Tag.Extraction import TermExtraction
-logging.config.fileConfig("logger.conf", disable_existing_loggers = False)
+logging.config.fileConfig("logger.conf")#, disable_existing_loggers = False)
 logger = logging.getLogger(__name__)
 
 # Arno: M2Crypto overrides the method for https:// in the


### PR DESCRIPTION
logging. Need another method for fixing this.
