### PR TITLE
Tribler did not cleanup VideoPlayer instance, caused test_video_server

### DIFF
--- a/Tribler/Main/tribler.py
+++ b/Tribler/Main/tribler.py
@@ -884,6 +884,7 @@ class ABCApp():
             self.guiserver.delInstance()
         if self.videoplayer:
             self.videoplayer.shutdown()
+            self.videoplayer.delInstance()
 
         delete_status_holders()
 

--- a/Tribler/Test/test_video_server.py
+++ b/Tribler/Test/test_video_server.py
@@ -99,16 +99,8 @@ class TestVideoHTTPServer(unittest.TestCase):
         self.register_file_stream()
 
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        for i in range(5): #attempt to connect 5 times, sleep for 5 seconds in between tries
-            try:
-                s.connect(('127.0.0.1', self.port))
-                break
-            except:
-                if i < 4:
-                    time.sleep(5)
-                else:
-                    raise
-
+        s.connect(('127.0.0.1', self.port))
+        
         head = self.get_std_header()
 
         head += "Range: bytes="

--- a/Tribler/Video/VideoPlayer.py
+++ b/Tribler/Video/VideoPlayer.py
@@ -58,6 +58,12 @@ class VideoPlayer:
             VideoPlayer(*args, **kw)
         return VideoPlayer.__single
     getInstance = staticmethod(getInstance)
+    
+    def delInstance(*args, **kw):
+        if VideoPlayer.__single and VideoPlayer.__single.videohttpserv:
+            VideoPlayer.__single.videohttpserv.delInstance()
+            VideoPlayer.__single = None
+    delInstance = staticmethod(delInstance)
 
     def hasInstance():
         return VideoPlayer.__single and VideoPlayer.__single.vlcwrap and VideoPlayer.__single.vlcwrap.initialized


### PR DESCRIPTION
to fail.
